### PR TITLE
Prefer schema over data type

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,4 @@ _ReSharper*/
 
 Source/Griffin.AdoNetFakes/Help/*
 Source/Griffin.AdoNetFakes/Fakes.shfbproj_*
+.vs/

--- a/Source/Griffin.AdoNetFakes/Griffin.AdNetFakes.Tests/CommandTests.cs
+++ b/Source/Griffin.AdoNetFakes/Griffin.AdNetFakes.Tests/CommandTests.cs
@@ -70,7 +70,7 @@ namespace Griffin.AdoNetFakes.Tests
             sut.CommandText = "UPDATE User SET Status = @status";
             sut.AddParameter("status", 1);
             sut.AddParameter("id", 22);
-            sut.ExecuteScalar();
+            Assert.Throws<CommandValidationException>(() => sut.ExecuteScalar());
         }
 
         [Fact]

--- a/Source/Griffin.AdoNetFakes/Griffin.AdNetFakes.Tests/FakeDataReaderTests.cs
+++ b/Source/Griffin.AdoNetFakes/Griffin.AdNetFakes.Tests/FakeDataReaderTests.cs
@@ -1,0 +1,40 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Data;
+using System.Linq;
+using System.Text;
+using Xunit;
+
+namespace Griffin.AdoNetFakes.Tests
+{
+    internal class Person
+    {
+        public int Id { get; set; }
+        public string Name { get;set; }
+        public DateTime DateOfBirth { get; set; }
+    }
+
+    public class FakeDataReaderTests
+    {
+        [Fact]
+        public void Construct_With_DataTable_leaves_SchemaType_as_default_RowData()
+        {
+            var table = new DataTable();
+
+            var sut = new FakeDataReader(table);
+
+            Assert.Equal(SchemaDataTypeSource.RowData, sut.SchemaDataTypeSource);
+        }
+
+        [Fact]
+        public void Construct_With_FakeTable_sets_SchemaType_to_DataTable()
+        {
+            var table = new FakeTable<Person>();
+            table.AddRowFromInstance(new Person { Id = 1, Name = "Bob", DateOfBirth = new DateTime(1980, 06, 15)});
+
+            var sut = new FakeDataReader(table);
+
+            Assert.Equal(SchemaDataTypeSource.DataTable, sut.SchemaDataTypeSource);
+        }
+    }
+}

--- a/Source/Griffin.AdoNetFakes/Griffin.AdNetFakes.Tests/FakeTableTTests.cs
+++ b/Source/Griffin.AdoNetFakes/Griffin.AdNetFakes.Tests/FakeTableTTests.cs
@@ -1,0 +1,36 @@
+﻿using System;
+using Xunit;
+
+namespace Griffin.AdoNetFakes.Tests
+{
+    public class FakeTableTTests
+    {
+        [Fact]
+        public void Construct_With_Type_sets_columns()
+        {
+            var sut = new FakeTable<Person>();
+
+            Assert.Equal(3, sut.Columns.Count);
+            Assert.Equal("Id", sut.Columns[0].ColumnName);
+            Assert.Equal("Name", sut.Columns[1].ColumnName);
+            Assert.Equal("DateOfBirth", sut.Columns[2].ColumnName);
+            Assert.Equal(typeof(int), sut.Columns[0].DataType);
+            Assert.Equal(typeof(string), sut.Columns[1].DataType);
+            Assert.Equal(typeof(DateTime), sut.Columns[2].DataType);
+        }
+
+        [Fact]
+        public void AddRowFromInstance_add_row_data_Correctly()
+        {
+            var row1 = new Person {Id = 1, Name = "Bob", DateOfBirth = new DateTime(1980, 06, 15)};
+
+            var sut = new FakeTable<Person>();
+            sut.AddRowFromInstance(row1);
+
+            Assert.Equal(1, sut.Rows.Count);
+            Assert.Equal(row1.Id, sut.Rows[0]["Id"]);
+            Assert.Equal(row1.Name, sut.Rows[0]["Name"]);
+            Assert.Equal(row1.DateOfBirth, sut.Rows[0]["DateOfBirth"]);
+        }
+    }
+}

--- a/Source/Griffin.AdoNetFakes/Griffin.AdNetFakes.Tests/Griffin.AdoNetFakes.Tests.csproj
+++ b/Source/Griffin.AdoNetFakes/Griffin.AdNetFakes.Tests/Griffin.AdoNetFakes.Tests.csproj
@@ -45,6 +45,8 @@
   <ItemGroup>
     <Compile Include="CommandTests.cs" />
     <Compile Include="ConnectionTests.cs" />
+    <Compile Include="FakeDataReaderTests.cs" />
+    <Compile Include="FakeTableTTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/Source/Griffin.AdoNetFakes/Griffin.AdoNetFakes/FakeDataReader.cs
+++ b/Source/Griffin.AdoNetFakes/Griffin.AdoNetFakes/FakeDataReader.cs
@@ -4,6 +4,13 @@ using System.Data;
 
 namespace Griffin.AdoNetFakes
 {
+    public enum SchemaDataTypeSource
+    {
+        RowData = 0,
+
+        DataTable = 1
+    }
+
     /// <summary>
     ///     Fake reader
     /// </summary>
@@ -21,6 +28,8 @@ namespace Griffin.AdoNetFakes
         private int _rowNumber = -1;
         private DataTable _schemaTable;
 
+        public SchemaDataTypeSource SchemaDataTypeSource { get; set; }
+
         /// <summary>
         ///     Initializes a new instance of the <see cref="FakeDataReader" /> class.
         /// </summary>
@@ -28,6 +37,12 @@ namespace Griffin.AdoNetFakes
         public FakeDataReader(DataTable table)
         {
             _table = table;
+
+            SchemaDataTypeSource = SchemaDataTypeSource.RowData;
+            if (table is FakeTable && table.GetType().IsGenericType && table.GetType().GetGenericTypeDefinition() == typeof(FakeTable<>))
+            {
+                SchemaDataTypeSource = SchemaDataTypeSource.DataTable;
+            }
         }
 
         /// <summary>
@@ -456,6 +471,11 @@ namespace Griffin.AdoNetFakes
         /// <returns></returns>
         public virtual Type GetFieldType(int ordinal)
         {
+            if (SchemaDataTypeSource == SchemaDataTypeSource.DataTable)
+            {
+                return _table.Columns[ordinal].DataType;
+            }
+
             if (_rowNumber == -1) throw new InvalidOperationException("Call Read() first.");
             return _table.Rows[_rowNumber][ordinal].GetType();
         }

--- a/Source/Griffin.AdoNetFakes/Griffin.AdoNetFakes/FakeTableT.cs
+++ b/Source/Griffin.AdoNetFakes/Griffin.AdoNetFakes/FakeTableT.cs
@@ -1,0 +1,50 @@
+﻿using System.Linq;
+using System.Reflection;
+
+namespace Griffin.AdoNetFakes
+{
+    public class FakeTable<T> : FakeTable
+    {
+        public static BindingFlags DefaultBindingFlags = BindingFlags.Instance | BindingFlags.Public | BindingFlags.GetProperty;
+
+        public FakeTable()
+            : this(DefaultBindingFlags)
+        {
+        }
+
+        public FakeTable(BindingFlags bindingFlags)
+        {
+            var properties = typeof(T).GetProperties(bindingFlags);
+
+            properties
+                .ToList()
+                .ForEach(pi => Columns.Add(pi.Name, pi.PropertyType));
+        }
+
+        public void AddRowFromInstance(T instance)
+        {
+            AddRowFromInstance(instance, DefaultBindingFlags);
+        }
+
+        public void AddRowFromInstance(T instance, BindingFlags bindingFlags)
+        {
+            var properties = typeof(T).GetProperties(bindingFlags);
+
+            var row = NewRow();
+
+            for (var i=0; i < Columns.Count; ++i)
+            {
+                var columnName = Columns[i].ColumnName;
+                var propertyInfo = properties.FirstOrDefault(pi => pi.Name.Equals(columnName));
+
+                var value = propertyInfo == null
+                    ? null
+                    : propertyInfo.GetValue(instance, null);
+
+                row[i] = value;
+            }
+
+            Rows.Add(row);
+        }
+    }
+}

--- a/Source/Griffin.AdoNetFakes/Griffin.AdoNetFakes/Griffin.AdoNetFakes.csproj
+++ b/Source/Griffin.AdoNetFakes/Griffin.AdoNetFakes/Griffin.AdoNetFakes.csproj
@@ -50,6 +50,9 @@
     <Compile Include="FakeTable.cs">
       <SubType>Component</SubType>
     </Compile>
+    <Compile Include="FakeTableT.cs">
+      <SubType>Component</SubType>
+    </Compile>
     <Compile Include="NamespaceDoc.cs" />
     <Compile Include="Factory.cs" />
     <Compile Include="FakeCommand.cs" />


### PR DESCRIPTION
I've added a FakeTable<T> to use type information to construct the columns. I've then extended the FakeDataReader to (optionally) use the DataTable for Field Info rather than waiting for the first row. This should enable AdoNetFakes to be used for testing Dapper which fails at present as it looks like Dapper is aggressively trying to read Field Info before the first Read().
